### PR TITLE
Include .env values in Docker

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,7 @@ version: '3'
 
 services:
   quetre:
+    env_file: .env
     build:
       context: .
       dockerfile: Dockerfile


### PR DESCRIPTION
This allows a user to set NO_UPGRADE=1 (or other configuration) in .env and have it apply to any docker-compose services.